### PR TITLE
Update TJS Currency title

### DIFF
--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -183,7 +183,7 @@
   <string name="long_syp">Syrian pound</string>
   <string name="long_szl">Swazi lilangeni</string>
   <string name="long_thb">Thai Baht</string>
-  <string name="long_tjs">Tajikistan Ruble</string>
+  <string name="long_tjs">Tajikistani somoni</string>
   <string name="long_tmt">New Turkmenistan Manat</string>
   <string name="long_tnd">Tunisian Dinar</string>
   <string name="long_top">Tongan pa\u02bbanga</string>


### PR DESCRIPTION
The correct name of TJS currency is Tajikistani somoni, not "Tajikistan rouble" https://en.wikipedia.org/wiki/Tajikistani_somoni :)